### PR TITLE
Fixed isSuccessful()

### DIFF
--- a/src/Message/BaseAbstractResponse.php
+++ b/src/Message/BaseAbstractResponse.php
@@ -20,6 +20,6 @@ abstract class BaseAbstractResponse extends AbstractResponse
     {
         $data = $this->getData();
 
-        return isset($data['result_code']) && $data['result_code'] == 'SUCCESS';
+        return isset($data['result_code']) && $data['result_code'] == 'SUCCESS' && $data['result_code'] == 'SUCCESS';
     }
 }


### PR DESCRIPTION
isSuccessful() must check $data['result_code'] == 'SUCCESS' , because
sometimes $data['result_code'] == 'FAIL' When $data['err_code'] ==
'INVALID_REQUEST' and  $data['err_code_des'] == '201 商户订单号重复'