### PR TITLE
support sub merchant

### DIFF
--- a/src/Message/BaseAbstractRequest.php
+++ b/src/Message/BaseAbstractRequest.php
@@ -63,4 +63,58 @@ abstract class BaseAbstractRequest extends AbstractRequest
     {
         $this->setParameter('mch_id', $mchId);
     }
+
+
+    /**
+     * @return mixed
+     */
+    public function getSubAppId()
+    {
+        return $this->getParameter('sub_app_id');
+    }
+
+
+    /**
+     * @param mixed $subAppId
+     */
+    public function setSubAppId($subAppId)
+    {
+        $this->setParameter('sub_app_id', $subAppId);
+    }
+
+
+    /**
+     * @return mixed
+     */
+    public function getSubMchId()
+    {
+        return $this->getParameter('sub_mch_id');
+    }
+
+
+    /**
+     * @param mixed $subMchId
+     */
+    public function setSubMchId($subMchId)
+    {
+        $this->setParameter('sub_mch_id', $subMchId);
+    }
+
+
+    /**
+     * @return mixed
+     */
+    public function getIsSubMch()
+    {
+        return $this->getParameter('is_sub_mch');
+    }
+
+
+    /**
+     * @param boolean $isSubMch
+     */
+    public function setIsSubMch($isSubMch)
+    {
+        $this->setParameter('is_sub_mch', $isSubMch);
+    }
 }

--- a/src/Message/CreateOrderRequest.php
+++ b/src/Message/CreateOrderRequest.php
@@ -42,6 +42,16 @@ class CreateOrderRequest extends BaseAbstractRequest
             $this->validate('open_id');
         }
 
+        $isSubMch = $this->getIsSubMch();
+
+        if($isSubMch === true)
+        {
+            $this->validate(
+                'sub_app_id',
+                'sub_mch_id'
+            );
+        }
+
         $data = array (
             'appid'            => $this->getAppId(),//*
             'mch_id'           => $this->getMchId(),
@@ -62,6 +72,12 @@ class CreateOrderRequest extends BaseAbstractRequest
             'openid'           => $this->getOpenId(),//*(trade_type=JSAPI)
             'nonce_str'        => md5(uniqid()),//*
         );
+
+        if($isSubMch === true)
+        {
+            $data['sub_appid'] = $this->getSubAppId();
+            $data['sub_mch_id'] = $this->getSubMchId();
+        }
 
         $data = array_filter($data);
 


### PR DESCRIPTION
增加服务商子商户支持，以is_sub_mch参数决定，设置为true则为服务商子商户发起的支付，需传入sub_app_id和sub_mch_id两项参数