### PR TITLE
更新Notify说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $response = $gateway->completePurchase([
 
 if ($response->isPaid()) {
     //pay success
-    var_dump($response->getData());
+    var_dump($response->getRequestData());
 }else{
     //pay fail
 }


### PR DESCRIPTION
L82这里由$response->getData() 改为 $response->getRequestData() , 后者才是处理业务逻辑所真正需要的信息, 否则容易引起歧义, 不仔细查看文档, 不容易发现getRequestData 这个接口