### PR TITLE
fixed  CreateOrderRequest中的openid参数错误

### DIFF
--- a/src/Message/CreateOrderRequest.php
+++ b/src/Message/CreateOrderRequest.php
@@ -39,7 +39,7 @@ class CreateOrderRequest extends BaseAbstractRequest
         $tradeType = strtoupper($this->getTradeType());
 
         if ($tradeType == 'JSAPI') {
-            $this->validate('open_id');
+            $this->validate('openid');
         }
 
         $data = array(
@@ -202,7 +202,7 @@ class CreateOrderRequest extends BaseAbstractRequest
      */
     public function getOpenId()
     {
-        return $this->getParameter('open_id');
+        return $this->getParameter('openid');
     }
 
 
@@ -334,7 +334,7 @@ class CreateOrderRequest extends BaseAbstractRequest
      */
     public function setOpenId($openId)
     {
-        $this->setParameter('open_id', $openId);
+        $this->setParameter('openid', $openId);
     }
 
 

--- a/src/Message/CreateOrderRequest.php
+++ b/src/Message/CreateOrderRequest.php
@@ -43,24 +43,24 @@ class CreateOrderRequest extends BaseAbstractRequest
         }
 
         $data = array(
-            'appid'            => $this->getAppId(),//*
+            'appid'            => $this->getAppId(),          //*
             'mch_id'           => $this->getMchId(),
-            'device_info'      => $this->getDeviceInfo(),//*
-            'body'             => $this->getBody(),//*
+            'device_info'      => $this->getDeviceInfo(),     //*
+            'body'             => $this->getBody(),           //*
             'detail'           => $this->getDetail(),
             'attach'           => $this->getAttach(),
-            'out_trade_no'     => $this->getOutTradeNo(),//*
+            'out_trade_no'     => $this->getOutTradeNo(),     //*
             'fee_type'         => $this->getFeeType(),
-            'total_fee'        => $this->getTotalFee(),//*
-            'spbill_create_ip' => $this->getSpbillCreateIp(),//*
-            'time_start'       => $this->getTimeStart(),//yyyyMMddHHmmss
-            'time_expire'      => $this->getTimeExpire(),//yyyyMMddHHmmss
+            'total_fee'        => $this->getTotalFee(),       //*
+            'spbill_create_ip' => $this->getSpbillCreateIp(), //*
+            'time_start'       => $this->getTimeStart(),      //yyyyMMddHHmmss
+            'time_expire'      => $this->getTimeExpire(),     //yyyyMMddHHmmss
             'goods_tag'        => $this->getGoodsTag(),
-            'notify_url'       => $this->getNotifyUrl(), //*
-            'trade_type'       => $this->getTradeType(), //*
+            'notify_url'       => $this->getNotifyUrl(),      //*
+            'trade_type'       => $this->getTradeType(),      //*
             'limit_pay'        => $this->getLimitPay(),
-            'openid'           => $this->getOpenId(),//*(trade_type=JSAPI)
-            'nonce_str'        => md5(uniqid()),//*
+            'openid'           => $this->getOpenId(),         //*(trade_type=JSAPI)
+            'nonce_str'        => md5(uniqid()),              //*
         );
 
         $data = array_filter($data);

--- a/src/Message/CreateOrderRequest.php
+++ b/src/Message/CreateOrderRequest.php
@@ -330,11 +330,11 @@ class CreateOrderRequest extends BaseAbstractRequest
 
 
     /**
-     * @param mixed $openId
+     * @param mixed $open_id
      */
-    public function setOpenId($openId)
+    public function setOpenId($open_id)
     {
-        $this->setParameter('openid', $openId);
+        $this->setParameter('openid', $open_id);
     }
 
 


### PR DESCRIPTION
在[公众号支付-统一下单接口文档](https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=9_1)说明结合本地代码测试，此字段应为openid而不是open_id，与企业付款接口中的openid一致。

另外，为了代码风格一致，将参数变量由openId改为open_id。

ps.
怪微信接口的文档不够规范，感觉像是多个部门分开弄的，像商户号在统一下单是叫mch_id，而在企业付款接口中却是mchid。