### PR TITLE
支持-微信普通服务商模式

### DIFF
--- a/src/BaseAbstractGateway.php
+++ b/src/BaseAbstractGateway.php
@@ -47,6 +47,44 @@ abstract class BaseAbstractGateway extends AbstractGateway
         return $this->getParameter('mch_id');
     }
 
+    /**
+     * 子商户id
+     *
+     * @return mixed
+     */
+    public function getSubMchId()
+    {
+        return $this->getParameter('sub_mch_id');
+    }
+
+
+    /**
+     * @param mixed $subMchId
+     */
+    public function setSubMchId($mchId)
+    {
+        $this->setParameter('sub_mch_id', $mchId);
+    }
+
+
+    /**
+     * 子商户 app_id
+     *
+     * @return mixed
+     */
+    public function getSubAppId()
+    {
+        return $this->getParameter('sub_appid');
+    }
+
+
+    /**
+     * @param mixed $subAppId
+     */
+    public function setSubAppId($subAppId)
+    {
+        $this->setParameter('sub_appid', $subAppId);
+    }
 
     public function setNotifyUrl($url)
     {

--- a/src/Message/BaseAbstractRequest.php
+++ b/src/Message/BaseAbstractRequest.php
@@ -63,4 +63,40 @@ abstract class BaseAbstractRequest extends AbstractRequest
     {
         $this->setParameter('mch_id', $mchId);
     }
+
+    /**
+     * @return mixed
+     */
+    public function getSubMchId()
+    {
+        return $this->getParameter('sub_mch_id');
+    }
+
+
+    /**
+     * @param mixed $subMchId
+     */
+    public function setSubMchId($mchId)
+    {
+        $this->setParameter('sub_mch_id', $mchId);
+    }
+
+    /**
+     * 子商户 app_id
+     *
+     * @return mixed
+     */
+    public function getSubAppId()
+    {
+        return $this->getParameter('sub_appid');
+    }
+
+
+    /**
+     * @param mixed $subAppId
+     */
+    public function setSubAppId($subAppId)
+    {
+        $this->setParameter('sub_appid', $subAppId);
+    }
 }

--- a/src/Message/CloseOrderRequest.php
+++ b/src/Message/CloseOrderRequest.php
@@ -31,6 +31,8 @@ class CloseOrderRequest extends BaseAbstractRequest
         $data = array(
             'appid'        => $this->getAppId(),
             'mch_id'       => $this->getMchId(),
+            'sub_appid'    => $this->getSubAppId(),
+            'sub_mch_id'   => $this->getSubMchId(),
             'out_trade_no' => $this->getOutTradeNo(),
             'nonce_str'    => md5(uniqid()),
         );

--- a/src/Message/CreateMicroOrderRequest.php
+++ b/src/Message/CreateMicroOrderRequest.php
@@ -30,6 +30,7 @@ class CreateMicroOrderRequest extends CreateOrderRequest
         $data = array(
             'appid'            => $this->getAppId(),//*
             'mch_id'           => $this->getMchId(),
+            'sub_mch_id'       => $this->getSubMchId(),
             'device_info'      => $this->getDeviceInfo(),//*
             'body'             => $this->getBody(),//*
             'detail'           => $this->getDetail(),

--- a/src/Message/CreateOrderRequest.php
+++ b/src/Message/CreateOrderRequest.php
@@ -45,6 +45,8 @@ class CreateOrderRequest extends BaseAbstractRequest
         $data = array(
             'appid'            => $this->getAppId(),//*
             'mch_id'           => $this->getMchId(),
+            'sub_appid'        => $this->getSubAppId(),
+            'sub_mch_id'       => $this->getSubMchId(),
             'device_info'      => $this->getDeviceInfo(),//*
             'body'             => $this->getBody(),//*
             'detail'           => $this->getDetail(),

--- a/src/Message/DownloadBillRequest.php
+++ b/src/Message/DownloadBillRequest.php
@@ -31,6 +31,8 @@ class DownloadBillRequest extends BaseAbstractRequest
         $data = array(
             'appid'       => $this->getAppId(),
             'mch_id'      => $this->getMchId(),
+            'sub_appid'   => $this->getSubAppId(),
+            'sub_mch_id'  => $this->getSubMchId(),
             'device_info' => $this->getDeviceInfo(),
             'bill_date'   => $this->getBillDate(),
             'bill_type'   => $this->getBillType(),//<>

--- a/src/Message/QueryOpenIdByAuthCodeRequest.php
+++ b/src/Message/QueryOpenIdByAuthCodeRequest.php
@@ -31,6 +31,7 @@ class QueryOpenIdByAuthCodeRequest extends BaseAbstractRequest
         $data = array(
             'appid'     => $this->getAppId(),
             'mch_id'    => $this->getMchId(),
+            'sub_mch_id'  => $this->getSubMchId(),
             'auth_code' => $this->getAuthCode(),
             'nonce_str' => md5(uniqid()),
         );

--- a/src/Message/QueryOrderRequest.php
+++ b/src/Message/QueryOrderRequest.php
@@ -35,6 +35,8 @@ class QueryOrderRequest extends BaseAbstractRequest
         $data = array(
             'appid'          => $this->getAppId(),
             'mch_id'         => $this->getMchId(),
+            'sub_appid'      => $this->getSubAppId(),
+            'sub_mch_id'     => $this->getSubMchId(),
             'transaction_id' => $this->getTransactionId(),
             'out_trade_no'   => $this->getOutTradeNo(),
             'nonce_str'      => md5(uniqid()),

--- a/src/Message/QueryRefundRequest.php
+++ b/src/Message/QueryRefundRequest.php
@@ -39,6 +39,8 @@ class QueryRefundRequest extends BaseAbstractRequest
         $data = array(
             'appid'          => $this->getAppId(),
             'mch_id'         => $this->getMchId(),
+            'sub_appid'      => $this->getSubAppId(),
+            'sub_mch_id'     => $this->getSubMchId(),
             'device_info'    => $this->getDeviceInfo(),
             'transaction_id' => $this->getTransactionId(),
             'out_trade_no'   => $this->getOutTradeNo(),

--- a/src/Message/RefundOrderRequest.php
+++ b/src/Message/RefundOrderRequest.php
@@ -32,6 +32,8 @@ class RefundOrderRequest extends BaseAbstractRequest
         $data = array(
             'appid'           => $this->getAppId(),
             'mch_id'          => $this->getMchId(),
+            'sub_appid'       => $this->getSubAppId(),
+            'sub_mch_id'      => $this->getSubMchId(),
             'device_info'     => $this->getDeviceInfo(),//<>
             'transaction_id'  => $this->getTransactionId(),
             'out_trade_no'    => $this->getOutTradeNo(),

--- a/src/Message/ShortenUrlRequest.php
+++ b/src/Message/ShortenUrlRequest.php
@@ -31,6 +31,7 @@ class ShortenUrlRequest extends BaseAbstractRequest
         $data = array(
             'appid'     => $this->getAppId(),
             'mch_id'    => $this->getMchId(),
+            'sub_mch_id'=> $this->getSubMchId(),
             'long_url'  => $this->getLongUrl(),
             'nonce_str' => md5(uniqid()),
         );


### PR DESCRIPTION
## 针对服务商模式-完成如下场景测试:
- JsApi-服务商收款 
- Native-服务商收款
- Notify-异步通知
- Query Order-查询订单
- Close Order-关闭订单
- Refund -退款
- QueryRefund-查询退款
- Shorten URL-转换短链

## 初始化
```
$gateway    = Omnipay::create('WechatPay');
$gateway->setAppId($config['app_id']);
$gateway->setMchId($config['mch_id']);
$gateway->setApiKey($config['api_key']);

//服务商模式下
$gateway->setSubmchId('子商户id'); 

//在小程序中使用服务商模式收款，查询订单等，此处为小程序app_id, 且必填， 非小程序场景不用设置。
//$gateway->setSubAppId('子商户app id'); 
```
- 备注 [小程序-服务商模式说明](https://pay.weixin.qq.com/wiki/doc/api/wxa/wxa_api.php?chapter=7_10&index=1)   [小程序-服务商收款-sub_appid使用说明](https://pay.weixin.qq.com/wiki/doc/api/wxa/wxa_api.php?chapter=7_12&index=6)

- 若检查无误，也希望 lokielse ，关注一下composer 包更新，感谢！